### PR TITLE
Regress dependencies with breaking changes in their latest versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,11 @@ source "http://rubygems.org"
 #   gem "activesupport", ">= 2.3.5"
 
 gem "autogc"
-gem "wref"
+gem "wref", "<= 0.0.6"
 gem "gir_ffi"
 gem "gtk3assist"
 gem "gettext"
-gem "knjrbfw"
+gem "knjrbfw", "<= 0.0.110"
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,43 +1,79 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     autogc (0.0.3)
-    datet (0.0.21)
+    builder (3.2.3)
+    datet (0.0.25)
     diff-lcs (1.1.3)
-    ffi (1.2.1)
-    gettext (2.3.7)
-      levenshtein
-      locale
-    gir_ffi (0.5.0)
-      ffi (~> 1.2.0)
-      indentation (~> 0.0.6)
-    gir_ffi-gtk (0.5.0)
-      gir_ffi (~> 0.5.0)
-    git (1.2.5)
+    faraday (0.8.11)
+      multipart-post (~> 1.2.0)
+    ffi (1.9.23)
+    ffi-bit_masks (0.1.1)
+      ffi (~> 1.0)
+    gettext (3.2.9)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gir_ffi (0.12.0)
+      ffi (~> 1.8)
+      ffi-bit_masks (~> 0.1.1)
+      indentation (~> 0.1.1)
+    gir_ffi-gtk (0.12.0)
+      gir_ffi (~> 0.12.0)
+    git (1.3.0)
+    github_api (0.10.1)
+      addressable
+      faraday (~> 0.8.1)
+      hashie (>= 1.2)
+      multi_json (~> 1.4)
+      nokogiri (~> 1.5.2)
+      oauth2
     gtk3assist (0.0.9)
       gir_ffi-gtk
       xml-simple
-    http2 (0.0.13)
-    indentation (0.0.7)
-    jeweler (1.8.4)
+    hashie (3.5.7)
+    highline (1.7.10)
+    http2 (0.0.32)
+      string-cases (~> 0)
+    indentation (0.1.1)
+    jeweler (1.8.8)
+      builder
       bundler (~> 1.0)
       git (>= 1.2.5)
+      github_api (= 0.10.1)
+      highline (>= 1.6.15)
+      nokogiri (= 1.5.10)
       rake
       rdoc
-    json (1.7.7)
-    knjrbfw (0.0.101)
+    json (1.8.6)
+    jwt (1.5.6)
+    knjrbfw (0.0.110)
       datet
       http2
       php4r
+      ruby_process
       tsafe
       wref
-    levenshtein (0.2.2)
-    locale (2.0.8)
-    php4r (0.0.3)
+    locale (2.1.2)
+    multi_json (1.13.1)
+    multi_xml (0.6.0)
+    multipart-post (1.2.0)
+    nokogiri (1.5.10)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    php4r (0.0.4)
       datet
       http2
-    rake (10.0.3)
-    rdoc (3.12.1)
+      string-strtr
+    public_suffix (3.0.2)
+    rack (2.0.4)
+    rake (12.3.1)
+    rdoc (3.12.2)
       json (~> 1.4)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
@@ -47,9 +83,16 @@ GEM
     rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
-    tsafe (0.0.11)
+    ruby_process (0.0.13)
+      string-cases
+      tsafe
+      wref
+    string-cases (0.0.4)
+    string-strtr (0.0.3)
+    text (1.3.1)
+    tsafe (0.0.12)
     wref (0.0.6)
-    xml-simple (1.1.2)
+    xml-simple (1.1.5)
 
 PLATFORMS
   ruby
@@ -61,7 +104,10 @@ DEPENDENCIES
   gir_ffi
   gtk3assist
   jeweler (~> 1.8.3)
-  knjrbfw
+  knjrbfw (<= 0.0.110)
   rdoc (~> 3.12)
   rspec (~> 2.8.0)
-  wref
+  wref (<= 0.0.6)
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
The dependency gems `wref` and `knjrbfw` both need to be regressed due to breaking changes in the latest versions of `wref`. There may be more regressions necessary however these two get things working again in what I've used this gem so far for.