### PR TITLE
Fix outdated usage of Wref

### DIFF
--- a/include/pulseaudio_sink.rb
+++ b/include/pulseaudio_sink.rb
@@ -8,7 +8,7 @@ class PulseAudio::Sink
   #The arguments-hash. Contains various data for the sink.
   attr_reader :args
   
-  @@sinks = Wref_map.new
+  @@sinks = Wref::Map.new
   
   #Used to look up IDs from names (like when getting default sink).
   @@sink_name_to_id_ref = {}
@@ -47,7 +47,7 @@ class PulseAudio::Sink
       sink_id = match[1].to_i
       args = {:sink_id => sink_id, :props => props}
       
-      sink = @@sinks.get!(sink_id)
+      sink = @@sinks[sink_id]
       if !sink
         sink = PulseAudio::Sink.new
         @@sinks[sink_id] = sink
@@ -81,7 +81,7 @@ class PulseAudio::Sink
   
   #This automatically reloads a sink when a 'change'-event appears.
   PulseAudio::Events.instance.connect(:event => :change, :element => "sink") do |args|
-    if @@sinks.key?(args[:args][:element_id]) and sink = @@sinks.get!(args[:args][:element_id])
+    if @@sinks.key?(args[:args][:element_id]) and sink = @@sinks[args[:args][:element_id]]
       sink.reload
     end
   end
@@ -96,7 +96,7 @@ class PulseAudio::Sink
   # sink = PulseAudio::Sink.by_id(3)
   def self.by_id(id)
     #Return it from the weak-reference-map, if it already exists there.
-    if sink = @@sinks.get!(id)
+    if sink = @@sinks[id]
       return sink
     end
     

--- a/include/pulseaudio_sink_input.rb
+++ b/include/pulseaudio_sink_input.rb
@@ -3,7 +3,7 @@ class PulseAudio::Sink::Input
   #The arguments-hash. Contains various data for the input.
   attr_reader :args
   
-  @@inputs = Wref_map.new
+  @@inputs = Wref::Map.new
   
   #Starts automatically redirect new opened inputs to the default sink.
   #===Examples
@@ -48,7 +48,7 @@ class PulseAudio::Sink::Input
       input_id = match[1].to_i
       args = {:input_id => input_id, :props => props}
 
-      input = @@inputs.get!(input_id)
+      input = @@inputs[input_id]
       if !input
         input = PulseAudio::Sink::Input.new
         @@inputs[input_id] = input
@@ -75,7 +75,7 @@ class PulseAudio::Sink::Input
   # sink_input = PulseAudio::Sink::Input.by_id(53)
   def self.by_id(id)
     #Return it from the weak-reference-map, if it already exists there.
-    if input = @@inputs.get!(id)
+    if input = @@inputs[id]
       return input
     end
     

--- a/include/pulseaudio_source.rb
+++ b/include/pulseaudio_source.rb
@@ -2,7 +2,7 @@ class PulseAudio::Source
   #The arguments-hash. Contains various data for the source.
   attr_reader :args
   
-  @@sources = Wref_map.new
+  @@sources = Wref::Map.new
   @@sources_name_to_id_ref = {}
   
   #Autoloader for subclasses.
@@ -24,7 +24,7 @@ class PulseAudio::Source
       source_id = match[1].to_i
       args = {:source_id => source_id, :props => props}
       
-      source = @@sources.get!(source_id)
+      source = @@sources[source_id]
       if !source
         source = PulseAudio::Source.new
         @@sources[source_id] = source
@@ -61,7 +61,7 @@ class PulseAudio::Source
   # source = PulseAudio::Source.by_id(3)
   def self.by_id(id)
     #Return it from the weak-reference-map, if it already exists there.
-    if source = @@sources.get!(id)
+    if source = @@sources[id]
       return source
     end
     
@@ -76,7 +76,7 @@ class PulseAudio::Source
   
   #This automatically reloads a source when a 'change'-event appears.
   PulseAudio::Events.instance.connect(:event => :change, :element => "source") do |args|
-    if @@sources.key?(args[:args][:element_id]) and source = @@sources.get!(args[:args][:element_id])
+    if @@sources.key?(args[:args][:element_id]) and source = @@sources[args[:args][:element_id]]
       source.reload
     end
   end

--- a/include/pulseaudio_source_output.rb
+++ b/include/pulseaudio_source_output.rb
@@ -1,6 +1,6 @@
 #Class for controlling outputs.
 class PulseAudio::Source::Output
-  @@outputs = Wref_map.new
+  @@outputs = Wref::Map.new
   
   #Starts automatically redirect new opened outputs to the default source.
   #===Examples
@@ -37,7 +37,7 @@ class PulseAudio::Source::Output
       output_id = match[0].to_i
       args = {:output_id => output_id}
       
-      output = @@outputs.get!(output_id)
+      output = @@outputs[output_id]
       if !output
         output = PulseAudio::Source::Output.new
         @@outputs[output_id] = output


### PR DESCRIPTION
The latest Wref changes `Wref_map` to `Wref::Map` and also inverts the meaning of `Wref::Map#get!` with `Wref::Map#get`. This caused the exception `PulseAudio::Sink::Wref_map (NameError)` to be thrown whenever trying to use any of the offending classes.