### PR TITLE
Fix 'Invalid volume specification' with pactl 12.2

### DIFF
--- a/include/pulseaudio_sink.rb
+++ b/include/pulseaudio_sink.rb
@@ -162,7 +162,7 @@ class PulseAudio::Sink
   #===Examples
   # sink.vol_incr if sink.active? #=> nil
   def vol_incr
-    %x[pactl set-sink-volume #{self.sink_id} -- +5%]
+    %x[pactl set-sink-volume #{self.sink_id} +5%]
     return nil
   end
   
@@ -170,7 +170,7 @@ class PulseAudio::Sink
   #===Examples
   # sink.vol_decr if sink.active? #=> nil
   def vol_decr
-    %x[pactl set-sink-volume #{self.sink_id} -- -5%]
+    %x[pactl set-sink-volume #{self.sink_id} -5%]
     return nil
   end
   


### PR DESCRIPTION
I'm not sure if this is a problem because of `pactl` changes? This change fixed the invalid volume specification message from pactl when increasing or decreasing the volume on a sink.